### PR TITLE
feat: add arrow key navigation to subject tree view

### DIFF
--- a/src/nnav/ui/screens.py
+++ b/src/nnav/ui/screens.py
@@ -994,6 +994,8 @@ class SubjectTreeScreen(ModalScreen[str | None]):
         Binding("s", "toggle_sort", "Sort", show=False),
         Binding("j", "cursor_down", "Down", show=False),
         Binding("k", "cursor_up", "Up", show=False),
+        Binding("down", "cursor_down", "Down", show=False),
+        Binding("up", "cursor_up", "Up", show=False),
     ]
 
     CSS = """


### PR DESCRIPTION
## Summary
- Added arrow key (up/down) navigation support to the subject tree screen
- Now supports both vim-style (j/k) and standard arrow key navigation

Closes #8