### PR TITLE
feat: add exclude filter with ! prefix syntax

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ make clean          # Remove caches and venv
 
 - Real-time streaming with wildcard subscriptions (`*`, `>`)
 - Request/response RPC matching with latency tracking
-- Filtering: text, regex (`/pattern/`), message type (REQ/RES/PUB), subject wildcards
+- Filtering: text, regex (`/pattern/`), exclude (`!pattern`), message type (REQ/RES/PUB), subject wildcards
 - Subject tree browser (hierarchical view with counts)
 - JSON syntax highlighting and path queries (`.user.name`)
 - Message diff between bookmarked messages
@@ -61,7 +61,7 @@ make clean          # Remove caches and venv
 |-----|--------|-----|--------|
 | j/k | Navigate | p | Pause/Resume |
 | Enter | View details | m | Bookmark |
-| / | Filter | n/N | Next/Prev bookmark |
+| / | Filter (use ! to exclude) | n/N | Next/Prev bookmark |
 | t | Type filter | d | Diff bookmarks |
 | T | Subject tree | y/Y | Copy payload/subject |
 | e/E | Export all/filtered | ? | Help |

--- a/src/nnav/ui/screens.py
+++ b/src/nnav/ui/screens.py
@@ -116,8 +116,9 @@ class HelpScreen(ModalScreen[None]):
 
             yield Label("Filtering & Search", classes="help-section")
             yield Label(
-                "  /          Filter messages (text or /regex/)", classes="help-row"
+                "  /          Filter messages (text, /regex/, !exclude)", classes="help-row"
             )
+            yield Label("             !pattern excludes matching messages", classes="help-row")
             yield Label("  Escape     Clear filter", classes="help-row")
             yield Label(
                 "  t          Filter by message type (REQ/RES/PUB)", classes="help-row"


### PR DESCRIPTION
## Summary
- Added `!` prefix syntax to exclude messages from filter results
- Single filter input now supports both include and exclude terms

## Filter Syntax
| Filter | Meaning |
|--------|---------|
| `orders` | Show messages containing "orders" |
| `!errors` | Hide messages containing "errors" |
| `/ord.*/` | Show messages matching regex |
| `!/err.*/` | Hide messages matching regex |
| `orders !errors` | Show "orders", hide "errors" |

## Changes
- Updated filter parsing to split terms by `!` prefix
- Include terms: message must match ALL
- Exclude terms: message must NOT match ANY
- Status bar shows include and exclude filters separately
- Updated help screen with new syntax

Closes #10